### PR TITLE
brace-style: allowSingleLine: true

### DIFF
--- a/index.js
+++ b/index.js
@@ -24,6 +24,7 @@ module.exports = {
     'indent': [2, 2, {
       SwitchCase: 1
     }],
+    'brace-style': [2, '1tbs', {allowSingleLine: true}],
     'space-before-function-paren': [2, 'never'],
     'valid-jsdoc': [2, {
       requireReturn: false,


### PR DESCRIPTION
The only guidance I can find on curly brace requirements in the [JS style guide](https://google.github.io/styleguide/javascriptguide.xml) defers to the [C++ style guide](https://google.github.io/styleguide/cppguide.html):

> In general, curly braces are not required for single-line statements, but they are allowed if you like them; conditional or loop statements with complex conditions or statements may be more readable with curly braces. Some groups require that an `if` must always always have an accompanying brace.

Therefore, `allowSingleLine` should be `true`.  This modules parent (`xo`) sets it to `false`.  Hence, I've added an override here that is identical to what's in `xo`, except for the `true`.