### PR TITLE
[fixed] curly

### DIFF
--- a/index.js
+++ b/index.js
@@ -24,7 +24,7 @@ module.exports = {
     'indent': [2, 2, {
       SwitchCase: 1
     }],
-    'brace-style': [2, '1tbs', {allowSingleLine: true}],
+    'curly': 0,
     'space-before-function-paren': [2, 'never'],
     'valid-jsdoc': [2, {
       requireReturn: false,


### PR DESCRIPTION
I made the mistake of using the GitHub inline editor for #13 and didn't
test it properly.  Though `block-style` was the one throwing the error,
`curly` was the one that needed changing.

This PR unsets `curly` to avoid inheriting `xo`'s default value, as
Google doesn't have a style opinion on this.  It also reverts the first
attempt at this fix (#13).

Sorry for the churn @addyosmani and @sindresorhus.  😞 