### PR TITLE
[added] no-unused-vars: args:none

### DIFF
--- a/index.js
+++ b/index.js
@@ -25,6 +25,9 @@ module.exports = {
       SwitchCase: 1
     }],
     'curly': 0,
+    'no-unused-vars': [2, {
+      "args": "none",
+    }],
     'space-before-function-paren': [2, 'never'],
     'valid-jsdoc': [2, {
       requireReturn: false,

--- a/index.js
+++ b/index.js
@@ -24,10 +24,6 @@ module.exports = {
     'indent': [2, 2, {
       SwitchCase: 1
     }],
-    'curly': 0,
-    'no-unused-vars': [2, {
-      "args": "none",
-    }],
     'space-before-function-paren': [2, 'never'],
     'valid-jsdoc': [2, {
       requireReturn: false,
@@ -39,6 +35,14 @@ module.exports = {
     'max-len': [1, 80, 4, {
       ignoreComments: true,
       ignoreUrls: true
-    }]
+    }],
+
+    //  Resetting things that eslint-config-xo has an opinion about, but the
+    //  Google Style Guide doesn't.
+    'curly': 0,
+    'no-floating-decimal': 0,
+    'no-unused-vars': [2, {
+      "args": "none",
+    }],
   }
 };


### PR DESCRIPTION
This is another case where @sindresorhus appears to be more opinionated
than Google is.  Moreover, there are valid reasons that you may have
unused arguments in a function, such as:

- To make it clear that the function is compatible with a particular
	API, like Event Listening:

	```
	function onClick(event) {}
	```

- To prevent future contributors from adding arguments that are
  incompatible with that signature

	```
	function toggleValue(event) {}
	```

	Even if the above `event` is unused, its presence reminds developers
	not to use the first argument position, as this function may be used
	as an event listener elsewhere.

- Because an API has changed and a parameter is no longer used, but you
	don't want to change the signature to avoid breaking people
	downstream.

Therefore, I'm disabling the no-unused-vars check on arguments.