### PR TITLE
[added] JSX support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,13 @@
 # eslint-config-google [![Build Status](https://travis-ci.org/google/eslint-config-google.svg?branch=master)](https://travis-ci.org/google/eslint-config-google)
 
-> ESLint [shareable config](http://eslint.org/docs/developer-guide/shareable-configs.html) for the [Google style](http://google.github.io/styleguide/javascriptguide.xml)
+> ESLint [shareable
+> config](http://eslint.org/docs/developer-guide/shareable-configs.html)
+> for [Google's JavaScript Style
+> Guide](http://google.github.io/styleguide/javascriptguide.xml)
 
-Note that there are some [rules](https://github.com/google/eslint-config-google/blob/master/index.js#L42-L46) the Google style guide isn't opinionated about and you might want to set yourself.
+Note that there are some [rules](https://github.com/google/eslint-config-
+google/blob/master/index.js#L42-L46) the Google style guide isn't opinionated
+about and you might want to set yourself.
 
 
 ## Install
@@ -32,6 +37,15 @@ Add some ESLint config to your `package.json`:
 ```
 
 Then lint with `$ npm run lint`.
+
+
+## Notes
+
+- We try to be supportive of the JavaScript ecosystem, even for projects
+  we don't use internally.  Therefore, we've applied the spirit of our [JS Style
+  Guide](https://google.github.io/styleguide/javascriptguide.xml) to
+  [JSX](https://facebook.github.io/jsx/) too.  Of course, if you don't use JSX,
+  these extra rules will be ignored.
 
 
 ## License

--- a/index.js
+++ b/index.js
@@ -75,6 +75,7 @@ module.exports = {
         initialized: 'never'
       }
     ],
+    'no-else-return': 'off',
     'curly': 'off',
     'no-floating-decimal': 'off',
     'padded-blocks': 'off',

--- a/index.js
+++ b/index.js
@@ -16,10 +16,15 @@
 'use strict';
 
 module.exports = {
+  parser: 'babel-eslint',
   extends: 'xo',
   globals: {
     goog: true
   },
+
+  plugins: [
+    'react'
+  ],
 
   rules: {
     'indent': [
@@ -29,7 +34,10 @@ module.exports = {
         SwitchCase: 1
       }
     ],
-    'space-before-function-paren': ['error', 'never'],
+    'space-before-function-paren': [
+      'error',
+      'never'
+    ],
     'valid-jsdoc': [
       'error',
       {
@@ -59,6 +67,34 @@ module.exports = {
       {
         args: 'none'
       }
+    ],
+
+    //  JSX support
+    'react/jsx-uses-react': 'warn',
+    'react/jsx-uses-vars': 'warn',
+    'jsx-quotes': [
+      'warn',
+      'prefer-single'
+    ],
+    'react/jsx-no-bind': 'warn',
+    'react/jsx-first-prop-new-line': 'warn',
+    'react/jsx-max-props-per-line': 'warn',
+    'react/react-in-jsx-scope': 'error',
+    'react/wrap-multilines': 'error',
+    'react/require-render-return': 'error',
+    'react/jsx-no-duplicate-props': 'error',
+    'react/jsx-pascal-case': 'error',
+    'react/jsx-space-before-closing': [
+      'error',
+      'always'
+    ],
+    'react/jsx-equals-spacing': [
+      'error',
+      'always'
+    ],
+    'react/jsx-curly-spacing': [
+      'error',
+      'always'
     ]
   }
 };

--- a/index.js
+++ b/index.js
@@ -20,29 +20,45 @@ module.exports = {
   globals: {
     goog: true
   },
+
   rules: {
-    'indent': [2, 2, {
-      SwitchCase: 1
-    }],
-    'space-before-function-paren': [2, 'never'],
-    'valid-jsdoc': [2, {
-      requireReturn: false,
-      prefer: {
-        returns: 'return'
+    'indent': [
+      'error',
+      2,
+      {
+        SwitchCase: 1
       }
-    }],
-    'require-jsdoc': 1,
-    'max-len': [1, 80, 4, {
-      ignoreComments: true,
-      ignoreUrls: true
-    }],
+    ],
+    'space-before-function-paren': ['error', 'never'],
+    'valid-jsdoc': [
+      'error',
+      {
+        requireReturn: false,
+        prefer: {
+          returns: 'return'
+        }
+      }
+    ],
+    'require-jsdoc': 'warn',
+    'max-len': [
+      'warn',
+      80,
+      4,
+      {
+        ignoreComments: true,
+        ignoreUrls: true
+      }
+    ],
 
     //  Resetting things that eslint-config-xo has an opinion about, but the
     //  Google Style Guide doesn't.
-    'curly': 0,
-    'no-floating-decimal': 0,
-    'no-unused-vars': [2, {
-      "args": "none",
-    }],
+    'curly': 'off',
+    'no-floating-decimal': 'off',
+    'no-unused-vars': [
+      'error',
+      {
+        args: 'none'
+      }
+    ]
   }
 };

--- a/index.js
+++ b/index.js
@@ -62,6 +62,13 @@ module.exports = {
     //  Google Style Guide doesn't.
     'curly': 'off',
     'no-floating-decimal': 'off',
+    'padded-blocks': 'off',
+    'no-multiple-empty-lines': [
+      'error',
+      {
+        max: 2
+      }
+    ],
     'no-unused-vars': [
       'error',
       {

--- a/index.js
+++ b/index.js
@@ -68,6 +68,13 @@ module.exports = {
 
     //  Resetting things that eslint-config-xo has an opinion about, but the
     //  Google Style Guide doesn't.
+    'one-var': [
+      'error',
+      {
+        uninitialized: 'always',
+        initialized: 'never'
+      }
+    ],
     'curly': 'off',
     'no-floating-decimal': 'off',
     'padded-blocks': 'off',

--- a/index.js
+++ b/index.js
@@ -27,6 +27,14 @@ module.exports = {
   ],
 
   rules: {
+    'quotes': [
+      'error',
+      'single',
+      {
+        avoidEscape: true,
+        allowTemplateLiterals: true
+      }
+    ],
     'indent': [
       'error',
       2,

--- a/package.json
+++ b/package.json
@@ -35,7 +35,9 @@
     "hint"
   ],
   "dependencies": {
-    "eslint-config-xo": "^0.13.0"
+    "babel-eslint": "6.0.4",
+    "eslint-plugin-react": "5.2.2",
+    "eslint-config-xo": "0.13.0"
   },
   "devDependencies": {
     "ava": "*",

--- a/test/test.js
+++ b/test/test.js
@@ -32,7 +32,11 @@ test(t => {
   t.true(isPlainObj(conf));
   t.true(isPlainObj(conf.rules));
 
-  const errors = runEslint(`'use strict'\nvar foo = function () {};\nfoo();\n`, conf);
+  const errors = runEslint(
+    `'use strict'\nvar foo = function () {};\nfoo();\n`,
+    conf
+  );
+
   t.is(errors[0].ruleId, 'semi');
   t.is(errors[1].ruleId, 'space-before-function-paren');
 });


### PR DESCRIPTION
Although we don't use JSX internally, we should still address it with our eslint config to support not only our own examples/tutorials, but also external parties who both want to follow our style guide and use React. Therefore, I've extended our rules to apply to JSX also.

These changes should be mostly innocuous for non-JSX code.  The biggest impact is the switch to the `babel-eslint` parser.  It's useful not-just for JSX, but for adding support for new JS features/proposals too. Overall, it seems more robust/configurable than the default parser, but it does introduce a new dependency (even for projects that aren't otherwise using Babel).
