### PR TITLE
Update all rules to match the new styleguide

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,5 +2,3 @@ language: node_js
 node_js:
   - '5'
   - '4'
-  - '0.12'
-  - '0.10'

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 > ESLint [shareable config](http://eslint.org/docs/developer-guide/shareable-configs.html) for the [Google style](http://google.github.io/styleguide/javascriptguide.xml)
 
-Note that there are some [rules](https://github.com/google/eslint-config-google/blob/master/index.js#L42-L46) the Google style guide isn't opinionated about and you might want to set yourself.
+Note that there are some [rules](https://github.com/google/eslint-config-google/blob/master/index.js) the Google style guide isn't opinionated about and you might want to set yourself.
 
 
 ## Install
@@ -22,7 +22,7 @@ Add some ESLint config to your `package.json`:
 		"lint": "eslint ."
 	},
 	"devDependencies": {
-		"eslint": "^2.7.0",
+		"eslint": "^3.5.0",
 		"eslint-config-google": "^0.5.0"
 	},
 	"eslintConfig": {

--- a/index.js
+++ b/index.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2015 Google Inc. All rights reserved.
+ * Copyright 2016 Google Inc. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,36 +13,304 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 'use strict';
 
 module.exports = {
-  extends: 'xo',
-  globals: {
-    goog: true
-  },
   rules: {
-    'indent': [2, 2, {
-      SwitchCase: 1
-    }],
-    'space-before-function-paren': [2, 'never'],
-    'valid-jsdoc': [2, {
-      requireReturn: false,
-      prefer: {
-        returns: 'return'
-      }
-    }],
-    'require-jsdoc': 1,
-    'max-len': [1, 80, 4, {
-      ignoreComments: true,
-      ignoreUrls: true
-    }],
+    // The rules below are listed in the order they appear on the eslint
+    // rules page. All rules are listed to make it easier to keep in sync
+    // as new ESLint rules are added.
+    // http://eslint.org/docs/rules/
+    // - Rules in the `eslint:recommended` ruleset that aren't specifically
+    //   mentioned by the google styleguide are listed but commented out (so
+    //   they don't override a base ruleset).
+    // - Rules that are recommended but contradict the Google styleguide
+    //   are explicitely set to the Google styleguide value.
 
-    //  Resetting things that eslint-config-xo has an opinion about, but the
-    //  Google Style Guide doesn't.
-    'curly': 0,
-    'no-floating-decimal': 0,
-    'no-unused-vars': [2, {
-      "args": "none",
+    // Possible Errors
+    // http://eslint.org/docs/rules/#possible-errors
+    // ---------------------------------------------
+    'no-cond-assign': 0, // eslint:recommended
+    // 'no-console': 2, // eslint:recommended
+    // 'no-condition': 2, // eslint:recommended
+    // 'no-constant-condition': 2, // eslint:recommended
+    // 'no-control-regex': 2, // eslint:recommended
+    // 'no-debugger': 2, // eslint:recommended
+    // 'no-dupe-args': 2, // eslint:recommended
+    // 'no-dupe-keys': 2, // eslint:recommended
+    // 'no-duplicate-case': 2, // eslint:recommended
+    // 'no-empty-character-class': 2, // eslint:recommended
+    // 'no-empty': 2, // eslint:recommended
+    // 'no-ex-assign': 2, // eslint:recommended
+    // 'no-extra-boolean-cast': 2, // eslint:recommended
+    // 'no-extra-parens': 0,
+    // 'no-extra-semi': 2, // eslint:recommended
+    // 'no-func-assign': 2, // eslint:recommended
+    // 'no-inner-declarations': 2, // eslint:recommended
+    // 'no-invalid-regexp': 2, // eslint:recommended
+    'no-irregular-whitespace': 2, // eslint:recommended
+    // 'no-obj-calls': 2, // eslint:recommended
+    // 'no-prototype-builtins': 0,
+    // 'no-regex-spaces': 2, // eslint:recommended
+    // 'no-sparse-arrays': 2, // eslint:recommended
+    // 'no-template-curly-in-string': 0,
+    'no-unexpected-multiline': 2, // eslint:recommended
+    // 'no-unreachable': 2, // eslint:recommended
+    // 'no-unsafe-finally': 2, // eslint:recommended
+    // 'no-unsafe-negation': 0,
+    // 'use-isnan': 2 // eslint:recommended
+    'valid-jsdoc': [2, {
+      requireParamDescription: false,
+      requireReturn: false,
+      prefer: {returns: 'return'},
     }],
-  }
+    // 'valid-typeof': 2 // eslint:recommended
+
+
+    // Best Practices
+    // http://eslint.org/docs/rules/#best-practices
+    // --------------------------------------------
+
+    // 'accessor-pairs': 0,
+    // 'array-callback-return': 0,
+    // 'block-scoped-var': 0,
+    // 'class-methods-use-this': 0,
+    // 'complexity': 0,
+    // 'consistent-return': 0
+    // 'curly': 0, // TODO(philipwalton): add an option to enforce braces with
+                   // the exception of simple, single-line if statements.
+    // 'default-case': 0,
+    // 'dot-location': 0,
+    // 'dot-notation': 0,
+    // 'eqeqeq': 0,
+    'guard-for-in': 2,
+    // 'no-alert': 0,
+    'no-caller': 2,
+    // 'no-case-declarations': 2, // eslint:recommended
+    // 'no-div-regex': 0,
+    // 'no-else-return': 0,
+    // 'no-empty-function': 0,
+    // 'no-empty-pattern': 2, // eslint:recommended
+    // 'no-eq-null': 0,
+    // 'no-eval': 0,
+    'no-extend-native': 2,
+    'no-extra-bind': 2,
+    // 'no-extra-label': 0,
+    // 'no-fallthrough': 2, // eslint:recommended
+    // 'no-floating-decimal': 0,
+    // 'no-global-assign': 0,
+    // 'no-implicit-coercion': 0,
+    // 'no-implicit-globals': 0,
+    // 'no-implied-eval': 0,
+    'no-invalid-this': 2,
+    // 'no-iterator': 0,
+    // 'no-labels': 0,
+    // 'no-lone-blocks': 0,
+    // 'no-loop-func': 0,
+    // 'no-magic-numbers': 0,
+    'no-multi-spaces': 2,
+    'no-multi-str': 2,
+    // 'no-new-func': 0,
+    'no-new-wrappers': 2,
+    // 'no-new': 0,
+    // 'no-octal-escape': 0,
+    // 'no-octal': 2, // eslint:recommended
+    // 'no-param-reassign': 0,
+    // 'no-proto': 0,
+    // 'no-redeclare': 2, // eslint:recommended
+    // 'no-return-assign': 0,
+    // 'no-script-url': 0,
+    // 'no-self-assign': 2, // eslint:recommended
+    // 'no-self-compare': 0,
+    // 'no-sequences': 0,
+    'no-throw-literal': 2, // eslint:recommended
+    // 'no-unmodified-loop-condition': 0,
+    // 'no-unused-expressions': 0,
+    // 'no-unused-labels': 2, // eslint:recommended
+    // 'no-useless-call': 0,
+    // 'no-useless-concat': 0,
+    // 'no-useless-escape': 0,
+    // 'no-void': 0,
+    // 'no-warning-comments': 0,
+    'no-with': 2,
+    // 'radix': 0,
+    // 'vars-on-top': 0,
+    // 'wrap-iife': 0,
+    // 'yoda': 0,
+
+    // Strict Mode
+    // http://eslint.org/docs/rules/#strict-mode
+    // -----------------------------------------
+    // 'script': 0,
+
+    // Variables
+    // http://eslint.org/docs/rules/#variables
+    // ---------------------------------------
+    // 'init-declarations': 0,
+    // 'no-catch-shadow': 0,
+    // 'no-delete-var': 2, // eslint:recommended
+    // 'no-label-var': 0,
+    // 'no-restricted-globals': 0,
+    // 'no-shadow-restricted-names': 0,
+    // 'no-shadow': 0,
+    // 'no-undef-init': 0,
+    // 'no-undef': 2, // eslint:recommended
+    // 'no-undefined': 0,
+    'no-unused-vars': [2, {args: 'none'}], // eslint:recommended
+    // 'no-use-before-define': 0,
+
+    // Node.js and CommonJS
+    // http://eslint.org/docs/rules/#nodejs-and-commonjs
+    // -------------------------------------------------
+    // 'callback-return': 0,
+    // 'global-require': 0,
+    // 'handle-callback-err': 0,
+    // 'no-mixed-requires': 0,
+    // 'no-new-require': 0,
+    // 'no-path-concat': 0,
+    // 'no-process-env': 0,
+    // 'no-process-exit': 0,
+    // 'no-restricted-modules': 0,
+    // 'no-restricted-properties': 0,
+    // 'no-sync': 0,
+
+    // Stylistic Issues
+    // http://eslint.org/docs/rules/#stylistic-issues
+    // ----------------------------------------------
+    'array-bracket-spacing': [2, 'never'],
+    // 'block-spacing': 0,
+    'brace-style': 2,
+    'camelcase': 2,
+    'comma-dangle': [2, 'always-multiline'],
+    'comma-spacing': 2,
+    'comma-style': 2,
+    'computed-property-spacing': 2,
+    // 'consistent-this': 0,
+    'eol-last': 2,
+    'func-call-spacing': 2,
+    // 'func-names': 0,
+    // 'func-style': 0,
+    // 'id-blacklist': 0,
+    // 'id-length': 0,
+    // 'id-match': 0,
+    // 'indent': 0, // TODO(philipwalton): this rule isn't compatible with
+                    // Google's 4-space indent for line continuations.
+    // 'jsx-quotes': 0,
+    'key-spacing': 2,
+    'keyword-spacing': 0,
+    // 'line-comment-position': 0,
+    'linebreak-style': 2,
+    // 'lines-around-comment': 0,
+    // 'lines-around-directive': 0,
+    // 'max-depth': 0,
+    'max-len': [2, {
+      code: 80,
+      tabWidth: 2,
+      ignoreUrls: true,
+      ignorePattern: '^goog\.(module|require)',
+    }],
+    // 'max-lines': 0,
+    // 'max-nested-callbacks': 0,
+    // 'max-params': 0,
+    // 'max-statements-per-line': 0,
+    // 'max-statements': 0,
+    // 'multiline-ternary': 0, // TODO(philipwalton): add a rule to enfore the
+                               // operator appearing at the end of the line.
+    'new-cap': 2,
+    // 'new-parens': 0,
+    // 'newline-after-var': 0,
+    // 'newline-before-return': 0,
+    // 'newline-per-chained-call': 0,
+    'no-array-constructor': 2,
+    // 'no-bitwise': 0,
+    // 'no-continue': 0,
+    // 'no-inline-comments': 0,
+    // 'no-lonely-if': 0,
+    // 'no-mixed-operators': 0,
+    'no-mixed-spaces-and-tabs': 2, // eslint:recommended
+    'no-multiple-empty-lines': [2, {max: 2}],
+    // 'no-negated-condition': 0,
+    // 'no-nested-ternary': 0,
+    'no-new-object': 2,
+    // 'no-plusplus': 0,
+    // 'no-restricted-syntax': 0,
+    // 'no-tabs': 0,
+    // 'no-ternary': 0,
+    'no-trailing-spaces': 2,
+    // 'no-underscore-dangle': 0,
+    // 'no-unneeded-ternary': 0,
+    // 'no-whitespace-before-property': 0,
+    // 'object-curly-newline': 0,
+    'object-curly-spacing': 2,
+    // 'object-property-newline': 0,
+    // 'one-var-declaration-per-line': 0,
+    'one-var': [2, {
+      var: 'never',
+      let: 'never',
+      const: 'never',
+    }],
+    // 'operator-assignment': 0,
+    // 'operator-linebreak': 0,
+    'padded-blocks': [2, 'never'],
+    'quote-props': [2, 'consistent'],
+    'quotes': [2, 'single', {allowTemplateLiterals: true}],
+    'require-jsdoc': [2, {
+      require: {
+        FunctionDeclaration: true,
+        MethodDefinition: true,
+        ClassDeclaration: true,
+      },
+    }],
+    'semi-spacing': 2,
+    'semi': 2,
+    // 'sort-keys': 0,
+    // 'sort-vars': 0,
+    'space-before-blocks': 2,
+    'space-before-function-paren': [2, 'never'],
+    // 'space-in-parens': 0,
+    // 'space-infix-ops': 0,
+    // 'space-unary-ops': 0,
+    'spaced-comment': [2, 'always'],
+    // 'unicode-bom': 0,
+    // 'wrap-regex': 0,
+
+    // ECMAScript 6
+    // http://eslint.org/docs/rules/#ecmascript-6
+    // ------------------------------------------
+    // 'arrow-body-style': 0,
+    'arrow-parens': [2, 'always'], // TODO(philipwalton): technically arrow
+                                   // parens are optional but recommended.
+                                   // ESLint doesn't support a *consistent*
+                                   // setting so "always" is used.
+    // 'arrow-spacing': 0,
+    'constructor-super': 2, // eslint:recommended
+    'generator-star-spacing': [2, 'after'],
+    // 'no-class-assign': 0,
+    // 'no-confusing-arrow': 0,
+    // 'no-const-assign': 0, // eslint:recommended
+    // 'no-dupe-class-members': 0, // eslint:recommended
+    // 'no-duplicate-imports': 0,
+    'no-new-symbol': 2, // eslint:recommended
+    // 'no-restricted-imports': 0,
+    'no-this-before-super': 2,  // eslint:recommended
+    // 'no-useless-computed-key': 0,
+    // 'no-useless-constructor': 0,
+    // 'no-useless-rename': 0,
+    'no-var': 2,
+    // 'object-shorthand': 0,
+    // 'prefer-arrow-callback': 0,
+    // 'prefer-const': 0,
+    // 'prefer-numeric-literals': 0,
+    // 'prefer-reflect': 0,
+    'prefer-rest-params': 2,
+    'prefer-spread': 2,
+    // 'prefer-template': 0,
+    // 'require-yield': 2, // eslint:recommended
+    'rest-spread-spacing': 2,
+    // 'sort-imports': 0,
+    // 'symbol-description': 0,
+    // 'template-curly-spacing': 0,
+    'yield-star-spacing': [2, 'after'],
+  },
 };

--- a/package.json
+++ b/package.json
@@ -2,14 +2,14 @@
   "name": "eslint-config-google",
   "version": "0.6.0",
   "description": "ESLint shareable config for the Google style",
-  "license": "Apache-2",
+  "license": "Apache-2.0",
   "repository": "google/eslint-config-google",
   "author": "Google",
   "engines": {
     "node": ">=0.10.0"
   },
   "scripts": {
-    "test": "ava"
+    "test": "node test/test.js"
   },
   "files": [
     "index.js"
@@ -34,16 +34,10 @@
     "enforce",
     "hint"
   ],
-  "dependencies": {
-    "eslint-config-xo": "^0.13.0"
-  },
   "devDependencies": {
-    "ava": "*",
-    "eslint": "^2.7.0",
-    "is-plain-obj": "^1.0.0",
-    "temp-write": "^2.0.1"
+    "eslint": "^3.5.0"
   },
   "peerDependencies": {
-    "eslint": ">=2.7.0"
+    "eslint": ">=3.5.0"
   }
 }

--- a/test/test.js
+++ b/test/test.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2015 Google Inc. All rights reserved.
+ * Copyright 2016 Google Inc. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,26 +13,30 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import test from 'ava';
-import isPlainObj from 'is-plain-obj';
-import tempWrite from 'temp-write';
-import eslint from 'eslint';
-import conf from '../';
 
-function runEslint(str, conf) {
-  const linter = new eslint.CLIEngine({
-    useEslintrc: false,
-    configFile: tempWrite.sync(JSON.stringify(conf))
-  });
+ 'use strict';
 
-  return linter.executeOnText(str).results[0].messages;
-}
+const assert = require('assert');
+const eslint = require('eslint');
+const conf = require('../');
 
-test(t => {
-  t.true(isPlainObj(conf));
-  t.true(isPlainObj(conf.rules));
+// The source files to lint.
+const repoFiles = [
+  'index.js',
+  'test/test.js',
+];
 
-  const errors = runEslint(`'use strict'\nvar foo = function () {};\nfoo();\n`, conf);
-  t.is(errors[0].ruleId, 'semi');
-  t.is(errors[1].ruleId, 'space-before-function-paren');
+// Use the rules defined in this repo to test against.
+const eslintOpts = {
+  envs: ['node', 'es6'],
+  useEslintrc: false,
+  rules: conf.rules,
+};
+
+// Runs the linter on the repo files and asserts no errors were found.
+const report = new eslint.CLIEngine(eslintOpts).executeOnFiles(repoFiles);
+assert.equal(report.errorCount, 0);
+assert.equal(report.warningCount, 0);
+repoFiles.forEach((file, index) => {
+  assert(report.results[index].filePath.endsWith(file));
 });


### PR DESCRIPTION
@addyosmani PTAL

I've gone through the new JavaScript styleguide (unfortunately still not public) and updated all ESLint rules to match (there's a lot of them, so we might want to have some other folks double-check).

As I say in the comments in `index.js`, I think the easiest way to keep this in sync with ESLint is to list all rules and comment out the ones that the Google styleguide doesn't have an opinion on.

I've opted not to extend the default `eslint:recommended` ruleset, though I anticipate lots of projects will want to do that, and they still can with something like this:

```json
{
  "extends": ["eslint:recommended", "google"]
}
```

There are a few rules in the Google styleguide that current ESLint rules can't fully enforce. As we have time going forward, we can add our own rules to handle some of those specific cases. As one quick example: Google style enforces braces around all conditional statements, but it makes an exception for short if-statements like the following:

```js
function foo() {
  if (shortConditional()) return;

  // ...
}
```
