### PR TITLE
Fix minor issue with rules

### DIFF
--- a/index.js
+++ b/index.js
@@ -61,6 +61,7 @@ module.exports = {
     // 'use-isnan': 2 // eslint:recommended
     'valid-jsdoc': [2, {
       requireParamDescription: false,
+      requireReturnDescription: false,
       requireReturn: false,
       prefer: {returns: 'return'},
     }],
@@ -180,7 +181,7 @@ module.exports = {
     'array-bracket-spacing': [2, 'never'],
     // 'block-spacing': 0,
     'brace-style': 2,
-    'camelcase': 2,
+    'camelcase': [2, {properties: 'never'}],
     'comma-dangle': [2, 'always-multiline'],
     'comma-spacing': 2,
     'comma-style': 2,


### PR DESCRIPTION
This PR fixes two minor issues with rules:

1) `valid-jsdoc` now allows you to omit a return description (which is allowed if the return description is implied by the type or other comments).

2) `camelcase` allows for properties to not be camelcase, which is common in Google code when dealing with JSON payloads where properties often contain keys like `access_token`.
