### PR TITLE
Fix: Update the indent rule

### DIFF
--- a/index.js
+++ b/index.js
@@ -197,7 +197,7 @@ module.exports = {
     // 'id-match': 0,
     'indent': [2, 2, {
       SwitchCase: 1,
-      VariableDeclarator: 2
+      VariableDeclarator: 2,
     }],
     // 'jsx-quotes': 0,
     'key-spacing': 2,

--- a/index.js
+++ b/index.js
@@ -195,8 +195,10 @@ module.exports = {
     // 'id-blacklist': 0,
     // 'id-length': 0,
     // 'id-match': 0,
-    // 'indent': 0, // TODO(philipwalton): this rule isn't compatible with
-                    // Google's 4-space indent for line continuations.
+    'indent': [2, 2, {
+      SwitchCase: 1,
+      VariableDeclarator: 2
+    }],
     // 'jsx-quotes': 0,
     'key-spacing': 2,
     'keyword-spacing': 0,

--- a/test/test.js
+++ b/test/test.js
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
- 'use strict';
+'use strict';
 
 const assert = require('assert');
 const eslint = require('eslint');


### PR DESCRIPTION
- 2-space indentation
- VariableDeclarator set to 2 will indent the multi-line variable declarations with 4 spaces
- SwitchCase set to 1 will indent case clauses with 2 spaces with respect to switch statements

Pulled from lighthouse eslintrc file.