### PR TITLE
Fix: Update curly lint rule

### DIFF
--- a/index.js
+++ b/index.js
@@ -78,8 +78,7 @@ module.exports = {
     // 'class-methods-use-this': 0,
     // 'complexity': 0,
     // 'consistent-return': 0
-    // 'curly': 0, // TODO(philipwalton): add an option to enforce braces with
-                   // the exception of simple, single-line if statements.
+    'curly': [2, 'multi-line'],
     // 'default-case': 0,
     // 'dot-location': 0,
     // 'dot-notation': 0,

--- a/index.js
+++ b/index.js
@@ -78,7 +78,9 @@ module.exports = {
     // 'class-methods-use-this': 0,
     // 'complexity': 0,
     // 'consistent-return': 0
-    'curly': [2, 'multi-line'],
+    'curly': [2, 'multi-line'], // TODO(philipwalton): add an option to enforce
+                                // braces with the exception of simple,
+                                // single-line if statements.
     // 'default-case': 0,
     // 'dot-location': 0,
     // 'dot-notation': 0,


### PR DESCRIPTION
Went with `multi-line` based on lighthouse's eslintrc rules.

`mutli-line`: allow brace-less single-line if, else if, else, for, while, or do

The alternative one would be,

`multi`: http://eslint.org/docs/rules/curly#multi