### PR TITLE
Require parens in arrow function arguments (arrow-parens)

### DIFF
--- a/index.js
+++ b/index.js
@@ -281,10 +281,9 @@ module.exports = {
     // http://eslint.org/docs/rules/#ecmascript-6
     // ------------------------------------------
     // 'arrow-body-style': 0,
-    'arrow-parens': [2, 'always'], // TODO(philipwalton): technically arrow
-                                   // parens are optional but recommended.
-                                   // ESLint doesn't support a *consistent*
-                                   // setting so "always" is used.
+    'arrow-parens': [2, 'as-needed', {
+      requireForBlockBody: true,
+    }],
     // 'arrow-spacing': 0,
     'constructor-super': 2, // eslint:recommended
     'generator-star-spacing': [2, 'after'],


### PR DESCRIPTION
> The "as-needed", { "requireForBlockBody": true } rule is directly inspired by the [Airbnb JS Style Guide](https://github.com/airbnb/javascript#arrows--one-arg-parens).

> If your function takes a single argument and doesn’t use braces, omit the parentheses. Otherwise, always include parentheses around arguments for clarity and consistency.