### PR TITLE
Enforcing double indentation of function arguments

### DIFF
--- a/index.js
+++ b/index.js
@@ -205,8 +205,7 @@ module.exports = {
     // 'id-blacklist': 0,
     // 'id-length': 0,
     // 'id-match': 0,
-    // 'indent': 0, // TODO(philipwalton): this rule isn't compatible with
-                    // Google's 4-space indent for line continuations.
+    'indent': ['error', 2, {'CallExpression': {'arguments': 2}}],
     // 'jsx-quotes': 0,
     'key-spacing': 2,
     'keyword-spacing': 2,


### PR DESCRIPTION
Fixing the `TODO` for the 4 space indentation in call expressions.