### PR TITLE
Require using Error objects in Promise rejection

### DIFF
--- a/index.js
+++ b/index.js
@@ -139,7 +139,7 @@ module.exports = {
     // 'no-void': 0,
     // 'no-warning-comments': 0,
     'no-with': 2,
-    // 'prefer-promise-reject-errors': 0,
+    'prefer-promise-reject-errors': 2,
     // 'radix': 0,
     // 'require-await': 0,
     // 'vars-on-top': 0,


### PR DESCRIPTION
It's now required in the internal style guide.