### PR TITLE
Whitelist ES6-style imports: const x = goog.require('x');

### DIFF
--- a/index.js
+++ b/index.js
@@ -237,7 +237,7 @@ module.exports = {
       code: 80,
       tabWidth: 2,
       ignoreUrls: true,
-      ignorePattern: '^goog\.(module|require)',
+      ignorePattern: 'goog\.(module|require)',
     }],
     // 'max-lines': 0,
     // 'max-nested-callbacks': 0,


### PR DESCRIPTION
goog.require('x');
is the old ES5 style, superseded by:
const x = goog.require('x');
