### PR TITLE
Ensure the proper placement of a break when wrapping an operator

### DIFF
--- a/index.js
+++ b/index.js
@@ -281,7 +281,7 @@ module.exports = {
     }],
     // 'one-var-declaration-per-line': 0,
     // 'operator-assignment': 0,
-    // 'operator-linebreak': 0,
+    'operator-linebreak': ['error', 'after'],
     'padded-blocks': [2, 'never'],
     // 'padding-line-between-statements': 0,
     'quote-props': [2, 'consistent'],

--- a/index.js
+++ b/index.js
@@ -206,7 +206,7 @@ module.exports = {
     // 'id-length': 0,
     // 'id-match': 0,
     'indent': [
-      'error', 2, {
+      2, 2, {
         'CallExpression': {
           'arguments': 2,
         },
@@ -281,7 +281,7 @@ module.exports = {
     }],
     // 'one-var-declaration-per-line': 0,
     // 'operator-assignment': 0,
-    'operator-linebreak': ['error', 'after'],
+    'operator-linebreak': [2, 'after'],
     'padded-blocks': [2, 'never'],
     // 'padding-line-between-statements': 0,
     'quote-props': [2, 'consistent'],
@@ -338,7 +338,7 @@ module.exports = {
     'no-var': 2,
     // 'object-shorthand': 0,
     // 'prefer-arrow-callback': 0,
-    'prefer-const': ['error', {destructuring: 'all'}],
+    'prefer-const': [2, {destructuring: 'all'}],
     // 'prefer-destructuring': 0,
     // 'prefer-numeric-literals': 0,
     'prefer-rest-params': 2,


### PR DESCRIPTION
The uncommented rule ensures the proper breaking of statements containing operators, in compliance with [the guide](https://google.github.io/styleguide/jsguide.html#formatting-where-to-break), more precisely with this statement:
> When a line is broken at an operator the break comes after the symbol.