### PR TITLE
chore: remove valid-jsdoc and require-jsdoc

### DIFF
--- a/index.js
+++ b/index.js
@@ -280,13 +280,6 @@ module.exports = {
     // 'padding-line-between-statements': 'off',
     'quote-props': ['error', 'consistent'],
     'quotes': ['error', 'single', {allowTemplateLiterals: true}],
-    'require-jsdoc': ['error', {
-      require: {
-        FunctionDeclaration: true,
-        MethodDefinition: true,
-        ClassDeclaration: true,
-      },
-    }],
     'semi': 'error',
     'semi-spacing': 'error',
     // 'semi-style': 'off',

--- a/index.js
+++ b/index.js
@@ -62,12 +62,6 @@ module.exports = {
     // 'no-unsafe-finally': 'error', // eslint:recommended
     // 'no-unsafe-negation': 'off',
     // 'use-isnan': 'error' // eslint:recommended
-    'valid-jsdoc': ['error', {
-      requireParamDescription: false,
-      requireReturnDescription: false,
-      requireReturn: false,
-      prefer: {returns: 'return'},
-    }],
     // 'valid-typeof': 'error' // eslint:recommended
 
 


### PR DESCRIPTION
update eslint-config-google to remove end-of-life'd option  https://eslint.org/blog/2018/11/jsdoc-end-of-life/

resolves #66 