### PR TITLE
chore: Update link to the newly named branch and Copyright

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# eslint-config-google [![Build Status](https://travis-ci.org/google/eslint-config-google.svg?branch=master)](https://travis-ci.org/google/eslint-config-google)
+# eslint-config-google
 
 > ESLint [shareable config](http://eslint.org/docs/developer-guide/shareable-configs.html) for the [Google JavaScript style guide (ES2015+ version)](https://google.github.io/styleguide/jsguide.html)
 

--- a/README.md
+++ b/README.md
@@ -38,9 +38,9 @@ To use Google style in conjunction with ESLint's recommended rule set, extend th
 }
 ```
 
-To see how the `google` config compares with `eslint:recommended`, refer to the [source code of `index.js`](https://github.com/google/eslint-config-google/blob/master/index.js), which lists every ESLint rule along with whether (and how) it is enforced by the `google` config.
+To see how the `google` config compares with `eslint:recommended`, refer to the [source code of `index.js`](https://github.com/google/eslint-config-google/blob/main/index.js), which lists every ESLint rule along with whether (and how) it is enforced by the `google` config.
 
 
 ## License
 
-Apache-2 © Google
+Apache-2 © Google, LLC

--- a/README.md
+++ b/README.md
@@ -43,4 +43,4 @@ To see how the `google` config compares with `eslint:recommended`, refer to the 
 
 ## License
 
-Apache-2 © Google, LLC
+See [License](https://github.com/google/eslint-config-google/blob/main/LICENSE)


### PR DESCRIPTION
super small update to README; fix link (auto-redirects currently to the renamed branch). Copyright line probably should be removed, but for now just updating to the OSPO naming convention. 